### PR TITLE
doc only: fold map and task descriptions of fn args, markdown for code examples

### DIFF
--- a/src/jepsen/history.clj
+++ b/src/jepsen/history.clj
@@ -14,7 +14,7 @@
 
   Create operations with the `op` function. Unlike most defrecords, we
   pretty-print these as if they were maps--we print a LOT of them.
-
+  ```
     (require '[jepsen.history :as h])
     (def o (h/op {:process 0, :type :invoke, :f :read, :value [:x nil],
                   :index 0, :time 0}))
@@ -25,108 +25,108 @@
     ;  :value [:x nil],
     ;  :index 0,
     ;  :time 0}
-
+  ```
   We provide a few common functions for interacting with operations:
-
+  ```
     (invoke? o)    ; true
     (client-op? o) ; true
     (info? o)      ; false
-
+  ```
   And of course you can use fast field accessors here too:
-
+  ```
     (.process o) ; 0
-
+  ```
   ## Histories
 
   Given a collection of operations, create a history like so:
-
+  ```
     (def h (h/history [{:process 0, :type :invoke, :f :read}
                        {:process 0, :type :ok, :f :read, :value 5}]))
-
+  ```
   `history` automatically lifts maps into Ops if they aren't already, and adds
   indices (sequential) and times (-1) if you omit them. There are options to
   control how indices are added; see `history` for details.
-
+  ```
     (pprint h)
     ; [{:process 0, :type :invoke, :f :read, :value nil, :index 0, :time -1}
     ;  {:process 0, :type :ok, :f :read, :value 5, :index 1, :time -1}]
-
+  ```
   If you need to convert these back to plain-old maps for writing tests, use
   `as-maps`.
-
+  ```
     (h/as-maps h)
     ; [{:index 0, :time -1, :type :invoke, :process 0, :f :read, :value nil}
     ;  {:index 1, :time -1, :type :ok, :process 0, :f :read, :value 5}]
-
+  ```
   Histories work almost exactly like vectors (though you can't assoc or conj
   into them).
-
+  ```
     (count h)
     ; 2
     (nth h 1)
     ; {:index 1, :time -1, :type :ok, :process 0, :f :read, :value 5}
     (map :type h)
     ; [:invoke :ok]
-
+  ```
   But they have a few extra powers. You can get the Op with a particular :index
   regardless of where it is in the collection.
-
+  ```
     (h/get-index h 0)
     ; {:index 0, :time -1, :type :invoke, :process 0, :f :read, :value nil}
-
+  ```
   And you can find the corresponding invocation for a completion, and
   vice-versa:
-
+  ```
     (h/invocation h {:index 1, :time -1, :type :ok, :process 0, :f :read,
                      :value 5})
     ; {:index 0, :time -1, :type :invoke, :process 0, :f :read, :value nil}
 
     (h/completion h {:index 0, :time -1, :type :invoke, :process 0, :f :read, :value nil})
     ; {:index 1, :time -1, :type :ok, :process 0, :f :read, :value 5}
-
+  ```
   We call histories where the :index fields are 0, 1, 2, ... 'dense', and other
   histories 'sparse'. With dense histories, `get-index` is just `nth`. Sparse
   histories are common when you're restricting yourself to just a subset of the
   history, like operations on clients. If you pass sparse indices to `(history
   ops)`, then ask for an op by index, it'll do a one-time fold over the ops to
   find their indices, then cache a lookup table to make future lookups fast.
-
+  ```
     (def h (history [{:index 3, :process 0, :type :invoke, :f :cas,
                       :value [7 8]}]))
     (h/dense-indices? h)
     ; false
     (get-index h 3)
     ; {:index 3, :time -1, :type :invoke, :process 0, :f :cas, :value [7 8]}
-
+  ```
   Let's get a slightly more involved history. This one has a concurrent nemesis
   crashing while process 0 writes 3.
-
+  ```
     (def h (h/history
              [{:process 0, :type :invoke, :f :write, :value 3}
               {:process :nemesis, :type :info, :f :crash}
               {:process 0, :type :ok, :f :write, :value 3}
               {:process :nemesis, :type :info, :f :crash}]))
-
+  ```
   Of course we can filter this to just client operations using regular seq
   operations...
-
+  ```
     (filter h/client-op? h)
     ; [{:process 0, :type :invoke, :f :write, :value 3, :index 0, :time -1}
     ;  {:process 0, :type :ok, :f :write, :value 3, :index 2, :time -1}]
-
+  ```
   But `jepsen.history` also exposes a more efficient version:
-
+  ```
     (h/filter h/client-op? h)
     ; [{:index 0, :time -1, :type :invoke, :process 0, :f :write, :value 3}
     ;  {:index 2, :time -1, :type :ok, :process 0, :f :write, :value 3}]
-
+  ```
   There are also shortcuts for common filtering ops: `client-ops`, `invokes`,
   `oks`, `infos`, and so on.
-
+  ```
     (def ch (h/client-ops h))
     (type ch)
     ; jepsen.history.FilteredHistory
-
+  ```
   Creating a filtered history is O(1), and acts as a lazy view on top of the
   underlying history. Like `clojure.core/filter`, it materializes elements as
   needed. Unlike Clojure's `filter`, it does not (for most ops) cache results
@@ -138,7 +138,7 @@
   invocations and completions, a FilteredHistory computes a small, reduced data
   structure on the fly, and caches it to make later operations of the same type
   fast.
-
+  ```
     (count ch) ; Folds over entire history to count how many match the predicate
     ; 2
     (count ch) ; Cached
@@ -148,7 +148,7 @@
 
     ; (h/get-index ch 2) ; No fold required; underlying history does get-index
     {:index 2, :time -1, :type :ok, :process 0, :f :write, :value 3}
-
+  ```
   Similarly, `h/map` constructs an O(1) lazy view over another history. These
   compose just like normal Clojure `map`/`filter`, and all share structure with
   the underlying history.
@@ -181,29 +181,29 @@
   which means multiple checkers can launch tasks on it without launching a
   bazillion threads. For instance, we might need to know if a history includes
   crashes:
-
+  ```
     (def first-crash (h/task h find-first-crash []
       (->> h (h/filter (comp #{:crash} :f)) first)))
-
+  ```
   Like futures, deref'ing a task yields its result, or throws.
-
+  ```
     @first-crash
     {:index 1, :time -1, :type :info, :process :nemesis, :f :crash,
      :value nil}
-
+  ```
   Unlike futures, tasks can express *dependencies* on other tasks:
-
+  ```
     (def ops-before-crash (h/task h writes [fc first-crash]
       (let [i (:index first-crash)]
         (into [] (take-while #(< (:index %) i)) h))))
-
+  ```
   This task won't run until first-crash has completed, and receives the result
   of the first-crash task as its argument.
-
+  ```
     @ops-before-crash
     ; [{:index 0, :time -1, :type :invoke, :process 0, :f :write, :value 3}]
-
-  See `jepsen.history.task` for more details."
+  ```
+  See [[jepsen.history.task]] for more details."
   (:refer-clojure :exclude [map filter remove])
   (:require [clojure [core :as c]
                      [pprint :as pprint :refer [pprint
@@ -1249,9 +1249,9 @@
 (defmacro task
   "A helper macro for launching new tasks. Takes a history, a symbol for your
   task name, optional data, a binding vector of names to dependency tasks you'd
-  like to depend on, and a single-arity argument vector, and a body. Wraps body
+  like to depend on, and a body. Wraps body
   in a function and submits it to the task executor.
-
+  ```
     (task history find-anomalies []
        ... go do stuff)
 
@@ -1259,7 +1259,8 @@
       ... do stuff with as)
 
     (task history data-task {:custom :data} [as anomalies, f furthermore]
-      ... do stuff with as and f)"
+      ... do stuff with as and f)
+   ```"
   [history task-name & args]
   (let [{:keys [dep-names deps data body]} (parse-task-args args)]
     `(task-call ~history '~task-name ~data [~@deps]

--- a/src/jepsen/history/task.clj
+++ b/src/jepsen/history/task.clj
@@ -3,51 +3,51 @@
   stateful executor for CPU-bound tasks backed by a num-cores
   ThreadPoolExecutor, and allows you to submit tasks to be run on that
   executor.
-
+  ```
     (require '[jepsen.history.task :as task])
     (def e (task/executor))
-
+  ```
   At a very high level, a task is a named function of optional dependencies
   (inputs) which returns an output. Here's a task with no dependencies:
-
+  ```
     (def pet (task/submit! e :pet-dog (fn [_] :petting-dog)))
-
+  ```
   Tasks are derefable with the standard blocking and nonblocking calls.
   Derefing a task returns its output. You can ask completion with `realized?`
-
+  ```
     @pet             ; :petting-dog
     (realized? pet)  ; true
-
+  ```
   If a task throws, its output is the Throwable it threw. Derefing that
   throwable also throws, like Clojure futures. Exceptions propagate to
   dependencies: dependencies will never execute, and if derefed, will throw as
   well.
-
+  ```
     (def doomed (task/submit! e :doomed (fn [_] (assert false))))
     ; All fine, until
     @doomed    ; throws Assert failed: false
-
+  ```
   Each task is assigned a unique long ID by its executor. Tasks should never be
   used across executors; their hashcodes and equality semantics are, for
   performance reasons, by ID *alone*.
-
+  ```
     (task/id pet)   ; 0
-
+  ```
   Tasks also have names, which can be any non-nil object, and are used for
   debugging & observability. Tasks can also carry an arbitrary data object,
   which can be anything you like. You can use this to build more sophisticated
   task management systems around this executor.
-
+  ```
     (task/name pet)   ; :pet-dog
 
     (def train (task/submit! e :train {:tricks [:down-stay :recall]} nil
                  (fn [_] :training-dog)))
     (task/data train)  ; {:tricks [:down-stay :recall]}
-
+  ```
   When submitted, tasks can depend on earlier tasks. When it executes, a task
   receives a vector of the outputs of its dependencies. A task only executes
   once its dependencies have completed, and will observe their memory effects.
-
+  ```
     (def dog-promise (promise))
     (def dog-task    (task/submit! e :make-dog    (fn [_] @dog-promise)))
     (def person-task (task/submit! e :make-person (fn [_] :nona)))
@@ -69,16 +69,16 @@
 
     ; Now we can deref the adoption task.
     @adopt-task    ; :adopted!
-
+  ```
   Tasks may be cancelled. Cancelling a task also cancels all tasks which depend
   on it. Unlike normal ThreadPoolExecutors, cancellation is *guaranteed* to be
   safe: if a task is still pending, it will never run. Cancelling a task which
   is running or has already run has no effect, other than removing it from the
   executor state. This may not be right for all applications; it's important
   for us.
-
+  ```
     (task/cancel! e adopt-task)
-
+  ```
   Tasks either run to completion or are cancelled; they are never interrupted.
   If they are, who knows what could happen? Almost certainly the executor will
   stall some tasks forever. Hopefully you're throwing away the executor and
@@ -90,7 +90,7 @@
   executor (fn [state] ...))`, which returns a new state. Any transformations
   you apply to the state take place atomically. Note that these functions use
   pure functions without `!`: `submit` instead of `submit!`, etc.
-
+  ```
     ; Create a task which blocks...
     (def dog-promise (promise))
     (def dog-task (task/submit! e :find-dog (fn [_] @dog-promise)))
@@ -112,9 +112,10 @@
                                     (prn :oh-no)
                                     :tomb-entered))]
           state'))))
-  ; prints :oh-no
-  (deliver dog-promise :noodle)
-  ; Adoption never happens!"
+    ; prints :oh-no
+    (deliver dog-promise :noodle)
+    ; Adoption never happens!
+  ```"
   (:refer-clojure :exclude [name])
   (:require [clojure [pprint :as pprint :refer [pprint]]]
             [clojure.tools.logging :refer [info warn fatal]]


### PR DESCRIPTION
Hi,

I'm starting a new checker for Elle, and in using the documentation for `history/fold/task` found two places with inaccuracies:

  - fold map description in `jepsen.history.fold`
    `:reducer*` and `:combiner*` functions don't take a `history` as the first arg

  - `jepsen.history/task` macro description
    macro doesn't take the single-arity argument vector mentioned

Also added markdown for code examples so the documentation, IDE help, etc is more usable/accessible.

----

A few observations:

The only thing that felt uncertain was the boundary with `ec/combine`.
If multiple graphs want to share task dependencies, they must be in an analyzer fn that combines the graph/explainers
before use by `(ec/combine my-combined-graphs process-graph)`.
I kept finding myself wanting to pass a dependency tree of tasks vs a function to `ec/combine`.

And it seems like submitting a task for each `:process` in a `history` to concurrently reduce (when you need to reduce over a `:process`'s ops) would be appropriate:

```clj
(->> processes
       (map #(h/task history (str :ww-wfr %) [] (ww-wfr-order history % ...)))
       (map deref)
       (reduce g/named-graph-union (g/linear (g/named-graph :ww-wfr (g/digraph))))
       g/forked)
```

Thanks for such an ergonomic way to process histories so efficiently!